### PR TITLE
Add SoftPosit library support | Improve build and comparison metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifdef SOFTPOSIT_ROOT
   SOFTPOSIT_STATIC := $(OUTDIR)/libsoftposit.a
 endif
 
-CXXFLAGS := -O2 -std=c++20 -Wall -Wextra $(OPENMP_FLAGS) $(UNIVERSAL_INCLUDE) $(SOFTPOSIT_INCLUDE)
+CXXFLAGS := -O3 -DNDEBUG -march=native -std=c++20 -Wall -Wextra $(OPENMP_FLAGS) $(UNIVERSAL_INCLUDE) $(SOFTPOSIT_INCLUDE)
 CPPFLAGS :=
 
 # Sources and output

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ OUT := $(OUTDIR)/fractal
 SCRIPT := ./run.sh
 PYTHON := python3
 
-.PHONY: all compile gen_all_images cfloat64_11 cfloat32_8 cfloat16_5 posit32_2 posit16_1 posit16_2 posit16_3 bfloat16_8 cfloat36_8 cfloat17_5 softposit32 softposit16 cpp_dec_float_100 compare install clean
+.PHONY: all compile gen_all_images cfloat64_11 cfloat32_8 cfloat16_5 posit32_2 posit16_1 posit16_2 posit16_3 bfloat16_8 cfloat36_8 cfloat17_5 softposit32 softposit16 cpp_dec_float_1000 compare install clean
 
 all: $(OUTDIR) compile gen_all_images compare
 
@@ -105,8 +105,8 @@ cfloat36_8: $(OUTDIR) compile
 cfloat17_5: $(OUTDIR) compile
 	$(SCRIPT) cfloat17_5
 
-cpp_dec_float_100: $(OUTDIR) compile
-	$(SCRIPT) cpp_dec_float_100
+cpp_dec_float_1000: $(OUTDIR) compile
+	$(SCRIPT) cpp_dec_float_1000
 
 softposit32: $(OUTDIR) compile
 	$(SCRIPT) softposit32

--- a/Makefile
+++ b/Makefile
@@ -1,64 +1,128 @@
-# Compiler and flags
+# Compiler and platform detection
+UNAME_S := $(shell uname -s)
+
+# Default compilers
 CXX := g++
-CXXFLAGS := -O2 -std=c++20 -fopenmp -Wall -Wextra
+CC  := gcc
+
+# OpenMP flags (set per-platform/toolchain)
+OPENMP_FLAGS := -fopenmp
+
+ifeq ($(UNAME_S),Darwin)
+  # Prefer Homebrew LLVM's clang/clang++ if available
+  BREW_PREFIX := $(shell brew --prefix 2>/dev/null)
+  LLVM_CLANGXX := $(BREW_PREFIX)/opt/llvm/bin/clang++
+  LLVM_CLANGC  := $(BREW_PREFIX)/opt/llvm/bin/clang
+  ifneq (,$(wildcard $(LLVM_CLANGXX)))
+    CXX := $(LLVM_CLANGXX)
+    CC  := $(LLVM_CLANGC)
+    # Use libomp from Homebrew
+    OPENMP_FLAGS := -fopenmp -I$(BREW_PREFIX)/opt/libomp/include -L$(BREW_PREFIX)/opt/libomp/lib -lomp -Wl,-rpath,$(BREW_PREFIX)/opt/libomp/lib
+  else
+    # Try Homebrew GCC (adjust version if needed)
+    CXX := g++-14
+    CC  := gcc-14
+    OPENMP_FLAGS := -fopenmp
+  endif
+endif
+
+# Optional: path to stillwater-sc/universal include directory
+# Supply as make UNIVERSAL_INC=/path/to/universal/include
+ifdef UNIVERSAL_INC
+  UNIVERSAL_INCLUDE := -I$(UNIVERSAL_INC)
+endif
+
+# Optional: SoftPosit library root (expects include/ and src/)
+# Supply as make SOFTPOSIT_ROOT=/path/to/soft-posit-cpp
+ifdef SOFTPOSIT_ROOT
+  SOFTPOSIT_INCLUDE := -I$(SOFTPOSIT_ROOT)/include -I$(SOFTPOSIT_ROOT)/include/8086-SSE -DENABLE_SOFTPOSIT
+  SOFTPOSIT_CFLAGS  := -O2 -std=c11 -Wall $(SOFTPOSIT_INCLUDE)
+  SOFTPOSIT_SRC_DIR := $(SOFTPOSIT_ROOT)/src
+  SOFTPOSIT_C_SOURCES := $(wildcard $(SOFTPOSIT_SRC_DIR)/*.c)
+  OUTDIR := build
+  SOFTPOSIT_OBJS_DIR := $(OUTDIR)/softposit
+  SOFTPOSIT_OBJS := $(patsubst $(SOFTPOSIT_SRC_DIR)/%.c,$(SOFTPOSIT_OBJS_DIR)/%.o,$(SOFTPOSIT_C_SOURCES))
+  SOFTPOSIT_STATIC := $(OUTDIR)/libsoftposit.a
+endif
+
+CXXFLAGS := -O2 -std=c++20 -Wall -Wextra $(OPENMP_FLAGS) $(UNIVERSAL_INCLUDE) $(SOFTPOSIT_INCLUDE)
+CPPFLAGS :=
 
 # Sources and output
 SRC := fractal.cpp
-OUTDIR := build
+OUTDIR ?= build
 OUT := $(OUTDIR)/fractal
 
 # Script
 SCRIPT := ./run.sh
 PYTHON := python3
 
-.PHONY: all compile gen_all_images cfloat64_11 cfloat32_8 cfloat16_5 posit32_2 posit16_1 posit16_2 posit16_3 bfloat16_8 cfloat36_8 cfloat17_5 compare install clean
+.PHONY: all compile gen_all_images cfloat64_11 cfloat32_8 cfloat16_5 posit32_2 posit16_1 posit16_2 posit16_3 bfloat16_8 cfloat36_8 cfloat17_5 softposit32 softposit16 compare install clean
 
 all: $(OUTDIR) compile gen_all_images compare
 
 $(OUTDIR):
 	mkdir -p $(OUTDIR)
 
-compile: $(OUTDIR)
-	$(CXX) $(CXXFLAGS) -o $(OUT) $(SRC)
+$(SOFTPOSIT_OBJS_DIR):
+	mkdir -p $(SOFTPOSIT_OBJS_DIR)
 
-cfloat64_11: $(OUTDIR)
+compile: $(OUTDIR) $(SOFTPOSIT_STATIC)
+	$(CXX) $(CXXFLAGS) -o $(OUT) $(SRC) $(SOFTPOSIT_STATIC)
+
+cfloat64_11: $(OUTDIR) compile
 	$(SCRIPT) cfloat64_11
 
-cfloat32_8: $(OUTDIR)
+cfloat32_8: $(OUTDIR) compile
 	$(SCRIPT) cfloat32_8
 
-cfloat16_5: $(OUTDIR)
+cfloat16_5: $(OUTDIR) compile
 	$(SCRIPT) cfloat16_5
 
-posit32_2: $(OUTDIR)
+posit32_2: $(OUTDIR) compile
 	$(SCRIPT) posit32_2
 
-posit16_1: $(OUTDIR)
+posit16_1: $(OUTDIR) compile
 	$(SCRIPT) posit16_1
 
-posit16_2: $(OUTDIR)
+posit16_2: $(OUTDIR) compile
 	$(SCRIPT) posit16_2
 
-posit16_3: $(OUTDIR)
+posit16_3: $(OUTDIR) compile
 	$(SCRIPT) posit16_3
 
-bfloat16_8: $(OUTDIR)
+bfloat16_8: $(OUTDIR) compile
 	$(SCRIPT) bfloat16_8
 
-cfloat36_8: $(OUTDIR)
+cfloat36_8: $(OUTDIR) compile
 	$(SCRIPT) cfloat36_8
 
-cfloat17_5: $(OUTDIR)
+cfloat17_5: $(OUTDIR) compile
 	$(SCRIPT) cfloat17_5
 
-gen_all_images:
+softposit32: $(OUTDIR) compile
+	$(SCRIPT) softposit32
+
+softposit16: $(OUTDIR) compile
+	$(SCRIPT) softposit16
+
+gen_all_images: compile
 	$(SCRIPT) all
 
 compare:
 	$(PYTHON) compare.py
 
 install:
-	pip install numpy opencv-python pillow scikit-image
+	pip install numpy opencv-python pillow scikit-image scipy
 
 clean:
 	rm -rf $(OUTDIR)
+
+# Build rules for SoftPosit C sources
+ifdef SOFTPOSIT_ROOT
+$(SOFTPOSIT_OBJS_DIR)/%.o: $(SOFTPOSIT_SRC_DIR)/%.c | $(SOFTPOSIT_OBJS_DIR)
+	$(CC) $(SOFTPOSIT_CFLAGS) -c $< -o $@
+
+$(SOFTPOSIT_STATIC): $(SOFTPOSIT_OBJS)
+	ar rcs $@ $(SOFTPOSIT_OBJS)
+endif

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ ifdef UNIVERSAL_INC
   UNIVERSAL_INCLUDE := -I$(UNIVERSAL_INC)
 endif
 
+# Optional: path to Boost headers (for cpp_dec_float). If not provided, rely on system include paths.
+ifdef BOOST_INC
+  BOOST_INCLUDE := -I$(BOOST_INC)
+endif
+
 # Optional: SoftPosit library root (expects include/ and src/)
 # Supply as make SOFTPOSIT_ROOT=/path/to/soft-posit-cpp
 ifdef SOFTPOSIT_ROOT
@@ -45,7 +50,7 @@ ifdef SOFTPOSIT_ROOT
   SOFTPOSIT_STATIC := $(OUTDIR)/libsoftposit.a
 endif
 
-CXXFLAGS := -O3 -DNDEBUG -march=native -std=c++20 -Wall -Wextra $(OPENMP_FLAGS) $(UNIVERSAL_INCLUDE) $(SOFTPOSIT_INCLUDE)
+CXXFLAGS := -O3 -DNDEBUG -march=native -std=c++20 -Wall -Wextra $(OPENMP_FLAGS) $(UNIVERSAL_INCLUDE) $(SOFTPOSIT_INCLUDE) $(BOOST_INCLUDE)
 CPPFLAGS :=
 
 # Sources and output
@@ -57,7 +62,7 @@ OUT := $(OUTDIR)/fractal
 SCRIPT := ./run.sh
 PYTHON := python3
 
-.PHONY: all compile gen_all_images cfloat64_11 cfloat32_8 cfloat16_5 posit32_2 posit16_1 posit16_2 posit16_3 bfloat16_8 cfloat36_8 cfloat17_5 softposit32 softposit16 compare install clean
+.PHONY: all compile gen_all_images cfloat64_11 cfloat32_8 cfloat16_5 posit32_2 posit16_1 posit16_2 posit16_3 bfloat16_8 cfloat36_8 cfloat17_5 softposit32 softposit16 cpp_dec_float_100 compare install clean
 
 all: $(OUTDIR) compile gen_all_images compare
 
@@ -99,6 +104,9 @@ cfloat36_8: $(OUTDIR) compile
 
 cfloat17_5: $(OUTDIR) compile
 	$(SCRIPT) cfloat17_5
+
+cpp_dec_float_100: $(OUTDIR) compile
+	$(SCRIPT) cpp_dec_float_100
 
 softposit32: $(OUTDIR) compile
 	$(SCRIPT) softposit32

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ After running, images are written to `build/`. The Python tool `compare.py` comp
 - IEEE: `cfloat64_11` (double), `cfloat32_8` (\_Float16), `cfloat16_5` (\_Float16)
 - Universal: `posit32_2`, `posit16_3`, `posit16_2`, `posit16_1`, `bfloat16_8`, `cfloat36_8`, `cfloat17_5`
 - SoftPosit: `softposit32`, `softposit16`
-- Boost.Multiprecision: `cpp_dec_float_100` ([cpp_dec_float](https://www.boost.org/doc/libs/1_77_0/libs/multiprecision/doc/html/boost_multiprecision/tut/floats/cpp_dec_float.html))
+- Boost.Multiprecision: `cpp_dec_float_1000` ([cpp_dec_float](https://www.boost.org/doc/libs/1_77_0/libs/multiprecision/doc/html/boost_multiprecision/tut/floats/cpp_dec_float.html))
 
-You select the dtype at runtime as the first CLI argument, e.g. `./fractal cpp_dec_float_100 ...`.
+You select the dtype at runtime as the first CLI argument, e.g. `./fractal cpp_dec_float_1000 ...`.
 
 ---
 
@@ -112,7 +112,7 @@ Or use the convenience script to generate multiple parameter sets:
 Make targets:
 
 - `make all` — build, run all dtypes, then compare
-- `make cfloat64_11|cfloat32_8|cfloat16_5|posit32_2|posit16_2|posit16_3|posit16_1|bfloat16_8|cfloat36_8|cfloat17_5|softposit32|softposit16|cpp_dec_float_100` — run a single dtype
+- `make cfloat64_11|cfloat32_8|cfloat16_5|posit32_2|posit16_2|posit16_3|posit16_1|bfloat16_8|cfloat36_8|cfloat17_5|softposit32|softposit16|cpp_dec_float_1000` — run a single dtype
 - `make compare` — compute metrics over images in `build/`
 - `make clean` — remove `build/`
 
@@ -139,13 +139,13 @@ Output naming convention:
 - Mandelbrot: `mandelbrot_<cx>_<cy>_<xside>_<dtype>.png`
 - Julia set: `julia_set_<cx>_<cy>_<xside>_<jc_x>_<jc_y>_<dtype>.png`
 
-`cpp_dec_float_100` serves as the comparison baseline in `compare.py`. See Boost docs: [cpp_dec_float](https://www.boost.org/doc/libs/1_77_0/libs/multiprecision/doc/html/boost_multiprecision/tut/floats/cpp_dec_float.html).
+`cpp_dec_float_1000` serves as the comparison baseline in `compare.py`. See Boost docs: [cpp_dec_float](https://www.boost.org/doc/libs/1_77_0/libs/multiprecision/doc/html/boost_multiprecision/tut/floats/cpp_dec_float.html).
 
 ---
 
 ## Comparison metrics (`compare.py`)
 
-For each parameter group (same location/scale, possibly same Julia constant), the following metrics are computed against the baseline image (`cpp_dec_float_100`):
+For each parameter group (same location/scale, possibly same Julia constant), the following metrics are computed against the baseline image (`cpp_dec_float_1000`):
 
 - `ssim` — Structural Similarity (higher is better)
 - `psnr` — Peak Signal‑to‑Noise Ratio in dB (higher is better)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fractals‑Posit (with SoftPosit)
 
-Generate and compare Mandelbrot and Julia‑set images across multiple numeric formats (IEEE, Universal library types, and SoftPosit).
+Generate and compare Mandelbrot and Julia‑set images across multiple numeric formats (IEEE, Universal library types, SoftPosit, and Boost.Multiprecision).
 
 After running, images are written to `build/`. The Python tool `compare.py` computes similarity metrics vs a high‑precision baseline and saves a CSV to `build/comparison_results.csv`.
 
@@ -8,11 +8,12 @@ After running, images are written to `build/`. The Python tool `compare.py` comp
 
 ## Supported numeric formats (dtype)
 
-- IEEE: `cfloat64_11` (double), `cfloat32_8` (float), `cfloat16_5` (\_Float16)
+- IEEE: `cfloat64_11` (double), `cfloat32_8` (\_Float16), `cfloat16_5` (\_Float16)
 - Universal: `posit32_2`, `posit16_3`, `posit16_2`, `posit16_1`, `bfloat16_8`, `cfloat36_8`, `cfloat17_5`
 - SoftPosit: `softposit32`, `softposit16`
+- Boost.Multiprecision: `cpp_dec_float_100` ([cpp_dec_float](https://www.boost.org/doc/libs/1_77_0/libs/multiprecision/doc/html/boost_multiprecision/tut/floats/cpp_dec_float.html))
 
-You select the dtype at runtime as the first CLI argument, e.g. `./fractal cfloat64_11 ...`.
+You select the dtype at runtime as the first CLI argument, e.g. `./fractal cpp_dec_float_100 ...`.
 
 ---
 
@@ -26,6 +27,9 @@ You select the dtype at runtime as the first CLI argument, e.g. `./fractal cfloa
 - Universal Number Library (headers only)
   - Clone `https://github.com/stillwater-sc/universal`
   - Set `UNIVERSAL_INC` to its include path (see Setup)
+- Boost.Multiprecision (headers only)
+  - Install Boost (e.g., macOS: `brew install boost`, Ubuntu: `sudo apt-get install libboost-dev`)
+  - Optionally set `BOOST_INC` if Boost is not in a default include path
 - SoftPosit (headers + C sources)
   - Clone `https://github.com/Posit-Foundation/soft-posit-cpp`
   ``` bash
@@ -67,6 +71,9 @@ export UNIVERSAL_INC="/absolute/path/to/universal/include/sw"
 
 # Path to soft-posit-cpp root (must have include/ and src/)
 export SOFTPOSIT_ROOT="/absolute/path/to/soft-posit-cpp"
+
+# Optional: path to Boost headers if not in a default include path
+export BOOST_INC="/opt/homebrew/include"
 ```
 
 Notes (macOS):
@@ -105,7 +112,7 @@ Or use the convenience script to generate multiple parameter sets:
 Make targets:
 
 - `make all` — build, run all dtypes, then compare
-- `make cfloat64_11|cfloat32_8|cfloat16_5|posit32_2|posit16_2|posit16_3|posit16_1|bfloat16_8|cfloat36_8|cfloat17_5|softposit32|softposit16` — run a single dtype
+- `make cfloat64_11|cfloat32_8|cfloat16_5|posit32_2|posit16_2|posit16_3|posit16_1|bfloat16_8|cfloat36_8|cfloat17_5|softposit32|softposit16|cpp_dec_float_100` — run a single dtype
 - `make compare` — compute metrics over images in `build/`
 - `make clean` — remove `build/`
 
@@ -132,13 +139,13 @@ Output naming convention:
 - Mandelbrot: `mandelbrot_<cx>_<cy>_<xside>_<dtype>.png`
 - Julia set: `julia_set_<cx>_<cy>_<xside>_<jc_x>_<jc_y>_<dtype>.png`
 
-`cfloat64_11` (double) serves as the comparison baseline in `compare.py`.
+`cpp_dec_float_100` serves as the comparison baseline in `compare.py`. See Boost docs: [cpp_dec_float](https://www.boost.org/doc/libs/1_77_0/libs/multiprecision/doc/html/boost_multiprecision/tut/floats/cpp_dec_float.html).
 
 ---
 
 ## Comparison metrics (`compare.py`)
 
-For each parameter group (same location/scale, possibly same Julia constant), the following metrics are computed against the baseline image (`cfloat64_11`):
+For each parameter group (same location/scale, possibly same Julia constant), the following metrics are computed against the baseline image (`cpp_dec_float_100`):
 
 - `ssim` — Structural Similarity (higher is better)
 - `psnr` — Peak Signal‑to‑Noise Ratio in dB (higher is better)

--- a/README.md
+++ b/README.md
@@ -1,140 +1,195 @@
-# Fractals‑Posit
+# Fractals‑Posit (with SoftPosit)
 
-A small C++ & Python toolchain to generate and compare Mandelbrot and Julia‑set fractal images using different numeric formats:
+Generate and compare Mandelbrot and Julia‑set images across multiple numeric formats (IEEE, Universal library types, and SoftPosit).
 
-- `float`, `_Float16` (half), `double`
-- `Posit<32,2>` and `Posit<16,2>`
-- `BFloat16`
-
-After running the code, the generated images are written to `build/`. The images can be compared via SSIM, histogram correlation and SIFT using the `compare.py` file, which results are stored in `build/comparison_results.csv`.
+After running, images are written to `build/`. The Python tool `compare.py` computes similarity metrics vs a high‑precision baseline and saves a CSV to `build/comparison_results.csv`.
 
 ---
 
-## Features
+## Supported numeric formats (dtype)
 
-- **C++** fractal generator with OpenMP
-- Support for IEEE floats, IEEE half‑precision, IEEE doubles, Posit and BFloat16 (via the *universal* library)
-- Automatic palette and PNG export (using [*stb\_image\_write*](https://github.com/nothings/stb/tree/master))
-- Bash script to run a variety of parameter sets
-- Python script to compute image similarity (SSIM, histogram, SIFT)
-- For increase performance the data type is defined in compilation time by the defines (`__USE_DATA_TYPE__ `, see `fractal.h`). No overloading
+- IEEE: `cfloat64_11` (double), `cfloat32_8` (float), `cfloat16_5` (\_Float16)
+- Universal: `posit32_2`, `posit16_3`, `posit16_2`, `posit16_1`, `bfloat16_8`, `cfloat36_8`, `cfloat17_5`
+- SoftPosit: `softposit32`, `softposit16`
+
+You select the dtype at runtime as the first CLI argument, e.g. `./fractal cfloat64_11 ...`.
 
 ---
 
 ## Prerequisites
 
-- A C++20‑capable compiler (e.g. `g++`) with OpenMP support
-- [Universal Number Library](https://github.com/stillwater-sc/universal) installed (headers on your include path)
-- Native support for IEEE-754 Double, Float and Half
-- Python 3.8+ with:
-  - `numpy`
-  - `opencv‑python`
-  - `pillow`
-  - `scikit‑image`
+- C++20 compiler with OpenMP
+  - macOS: Homebrew LLVM (`brew install llvm libomp`) is auto‑detected
+  - Linux: GCC 10+ (with `-fopenmp`) is recommended
+- Python 3.8+
+  - `numpy`, `opencv‑python`, `pillow`, `scikit‑image`, `scipy`
+- Universal Number Library (headers only)
+  - Clone `https://github.com/stillwater-sc/universal`
+  - Set `UNIVERSAL_INC` to its include path (see Setup)
+- SoftPosit (headers + C sources)
+  - Clone `https://github.com/Posit-Foundation/soft-posit-cpp`
+  - This repo expects the soft‑posit C/C++ headers and sources from `soft-posit-cpp` to be available
+  - Set `SOFTPOSIT_ROOT` to the repo root (must contain `include/` and `src/`)
 
 ---
 
-## Quickstart
+## Setup (reproducible)
 
-1. **Clone** this repo
+1. Clone repos
 
-   ```bash
-   git clone https://github.com/Joao-Pedro-Cabral/Fractals-Posit.git
-   cd Fractals-Posit
-   ```
+```bash
+git clone https://github.com/Joao-Pedro-Cabral/Fractals-Posit.git
+cd Fractals-Posit
 
-2. **Install** Python dependencies
+# Also have these locally (adjust paths as needed):
+# universal: https://github.com/stillwater-sc/universal
+# soft-posit-cpp: https://github.com/Posit-Foundation/soft-posit-cpp
+```
 
-   ```bash
-   make install
-   ```
+2. Install Python packages
 
-3. **Build & run** all variants and compare
+```bash
+make install
+```
 
-   ```bash
-   make all
-   ```
+3. Set include/library paths (one‑time per shell)
 
-   This will:
+```bash
+# Path to universal headers (the directory that contains sw/universal/...)
+export UNIVERSAL_INC="/absolute/path/to/universal/include/sw"
 
-   - Compile and run the fractal generator in `build/` for each numeric type
-   - Generate PNGs in `build/`
-   - Run `compare.py build`, producing `build/comparison_results.csv`
+# Path to soft-posit-cpp root (must have include/ and src/)
+export SOFTPOSIT_ROOT="/absolute/path/to/soft-posit-cpp"
+```
 
-4. **Inspect** your images in `build/` and open the CSV for detailed SSIM/histogram/SIFT scores.
+Notes (macOS):
+
+- Ensure Homebrew LLVM and libomp are installed: `brew install llvm libomp`
+- The Makefile will auto‑detect Homebrew LLVM and link against libomp
+- You can override compilers via `CXX`/`CC` if needed
 
 ---
 
-## Makefile Targets
+## Build and run
 
-- `make all`\
-  Compile & run (`float`, `double`, `half`, `posit32_2`, `posit16_2`, `bfloat16`), then compare
-- `make float|double|half|posit32_2|posit16_2|bfloat16`\
-  Build & run one numeric type
-- `make compare`\
-  Only compare images stored in `build/`
-- `make clean`\
-  Remove the entire `build/` directory and all outputs
+Build the fractal generator and the SoftPosit static library, then run a few images:
+
+```bash
+make UNIVERSAL_INC="$UNIVERSAL_INC" SOFTPOSIT_ROOT="$SOFTPOSIT_ROOT" compile
+
+# Example: generate a small set of images from the build directory
+cd build
+./fractal cfloat64_11 mandelbrot -0.759 0.000 2.500
+./fractal softposit32  mandelbrot -0.759 0.000 2.500
+./fractal softposit16  mandelbrot -0.759 0.000 2.500
+./fractal posit32_2    mandelbrot -0.759 0.000 2.500
+./fractal cfloat32_8   mandelbrot -0.759 0.000 2.500
+```
+
+Or use the convenience script to generate multiple parameter sets:
+
+```bash
+# from the repo root
+./run.sh all     # builds & runs many parameter sets for each dtype
+./run.sh ieee    # builds & runs only IEEE float/double/half sets
+./run.sh compare # just runs comparison on existing images in build/
+```
+
+Make targets:
+
+- `make all` — build, run all dtypes, then compare
+- `make cfloat64_11|cfloat32_8|cfloat16_5|posit32_2|posit16_2|posit16_3|posit16_1|bfloat16_8|cfloat36_8|cfloat17_5|softposit32|softposit16` — run a single dtype
+- `make compare` — compute metrics over images in `build/`
+- `make clean` — remove `build/`
 
 ---
 
-## Fractal Command‑Line
+## Program usage
 
-You can also invoke the binary directly:
+Binary runs from `build/` and takes the dtype as first argument:
 
 ```bash
-g++ -O2 -std=c++20 -fopenmp -D__USE_DATA_TYPE__ -o build/fractal fractal.cpp
-build/fractal mandelbrot <center_x> <center_y> <xside>
-build/fractal julia_set <center_x> <center_y> <xside> <julia_cx> <julia_cy>
+./fractal <dtype> mandelbrot <center_x> <center_y> <xside>
+./fractal <dtype> julia_set  <center_x> <center_y> <xside> <julia_cx> <julia_cy>
 ```
 
-E.g.:
+Examples:
 
 ```bash
-g++ -O2 -std=c++20 -fopenmp -D__USE_POSIT_32_2__ -o build/fractal fractal.cpp
-build/fractal mandelbrot -0.74548 0.11669 0.01276
-build/fractal julia_set 0.00000 0.00000 3.00000 -0.4 -0.59
+./fractal cfloat64_11 mandelbrot -0.74548 0.11669 0.01276
+./fractal softposit32 julia_set  0.00000  0.00000 3.00000  -0.4 -0.59
+```
+
+Output naming convention:
+
+- Mandelbrot: `mandelbrot_<cx>_<cy>_<xside>_<dtype>.png`
+- Julia set: `julia_set_<cx>_<cy>_<xside>_<jc_x>_<jc_y>_<dtype>.png`
+
+`cfloat64_11` (double) serves as the comparison baseline in `compare.py`.
+
+---
+
+## Comparison metrics (`compare.py`)
+
+For each parameter group (same location/scale, possibly same Julia constant), the following metrics are computed against the baseline image (`cfloat64_11`):
+
+- `ssim` — Structural Similarity (higher is better)
+- `psnr` — Peak Signal‑to‑Noise Ratio in dB (higher is better)
+- `mse` — Mean Squared Error (lower is better)
+- `hist` — 3D RGB histogram correlation (higher is better)
+- `sift` — SIFT keypoint match rate (higher is better)
+- `fft_rmse` — RMSE of log‑magnitude FFTs (lower is better)
+
+Results are written to `build/comparison_results.csv` with headers:
+
+```
+parameters, cfloat32_8_ssim, cfloat16_5_ssim, ..., softposit16_fft_rmse
+```
+
+If a dtype image is missing for a parameter group, the CSV cell is left empty for that metric.
+
+---
+
+## Implementation notes
+
+- Image size: `WIDTH=800`, `HEIGHT=600`, RGB PNG
+- Max iterations: `MAXCOUNT=1000`
+- Coordinate setup:
+
+```bash
+yside = xside * HEIGHT / WIDTH
+left  = center_x - xside / 2
+top   = center_y - yside / 2
+
+// Mandelbrot
+cx = x * (xside / WIDTH)  + left
+cy = y * (yside / HEIGHT) + top
+
+// Julia
+zx = x * (xside / WIDTH)  + left
+zy = y * (yside / HEIGHT) + top
 ```
 
 ---
 
-## Note about the inputs
+## Troubleshooting
 
-Different implementations of the Mandelbrot and Julia sets often use different conventions for how the points are calculated based on the input parameters.
+- OpenMP on macOS: install `llvm` and `libomp` via Homebrew. The Makefile auto‑detects and links to libomp.
+- SoftPosit headers: ensure `SOFTPOSIT_ROOT` points to a tree with `include/` and `src/`. The Makefile adds both `include/` and `include/8086‑SSE/` to the include path.
+- Universal headers: set `UNIVERSAL_INC` to the directory that contains `sw/universal/...` (typically `<repo>/include/sw`).
+- Python: if OpenCV SIFT is unavailable, install `opencv-contrib-python` or keep `opencv-python` (which ships SIFT in recent versions).
 
-In this implementation, the output image dimensions are defined as:
-
-```bash
-HEIGHT = 600, WIDTH = 800;
-yside = xside * HEIGHT / WIDTH;
-left = center_x - xside / 2;
-top = center_y - yside / 2;
-```
-
-Additionaly, for Mandelbrot set, the constant **c** is defined as:
-
-```bash
-xscale = xside / WIDTH;
-yscale = yside / HEIGHT;
-cx = x * xscale + left;
-cy = y * yscale + top;
-```
-
-For the Julia set, the coordinates of **z** are computed in the same way as **c** in the Mandelbrot set:
-
-```bash
-zx = x * xscale + left;
-zy = y * yscale + top;
-```
+---
 
 ## References
 
-The fractal inputs used in the `run.sh` script are obtained from the following links:
+Fractal viewpoints used in `run.sh` were sourced from:
 
-https://www.mrob.com/pub/muency/seahorsevalley.html
-https://en.wikipedia.org/wiki/Julia_set
-https://paulbourke.net/fractals/juliaset/index.html
-https://paulbourke.net/fractals/mandelbrot/
-https://forums.raspberrypi.com/viewtopic.php?t=21029
+<https://www.mrob.com/pub/muency/seahorsevalley.html>
+<https://en.wikipedia.org/wiki/Julia_set>
+<https://paulbourke.net/fractals/juliaset/index.html>
+<https://paulbourke.net/fractals/mandelbrot/>
+<https://forums.raspberrypi.com/viewtopic.php?t=21029>
+<https://github.com/Posit-Foundation/soft-posit-cpp/blob/refactor-cpp-soft-posits/README.md>
 
 ---

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ You select the dtype at runtime as the first CLI argument, e.g. `./fractal cfloa
   - Set `UNIVERSAL_INC` to its include path (see Setup)
 - SoftPosit (headers + C sources)
   - Clone `https://github.com/Posit-Foundation/soft-posit-cpp`
+  ``` bash
+  # Clone SoftPosit with specific commit
+  git clone https://github.com/Posit-Foundation/soft-posit-cpp.git
+  cd soft-posit-cpp
+  git checkout 0ff15525c20c11de588eac4168df03428d9ec287
+  cd ..
+  ```
   - This repo expects the soft‑posit C/C++ headers and sources from `soft-posit-cpp` to be available
   - Set `SOFTPOSIT_ROOT` to the repo root (must contain `include/` and `src/`)
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Purpose: reproducible build/run of Fractals-Posit-Fork with Boost cpp_dec_float_1000 baseline
+#
+# Usage examples:
+#   ./build.sh                         # clean + build only
+#   RUN_BASELINE=1 ./build.sh          # also run baseline image with timing
+#   RUN_ALL=1 ./build.sh               # run all dtypes for the default view (can be slow!)
+#
+# Environment variables you can override:
+#   UNIVERSAL_INC  -> path that contains sw/universal/... headers (default set below)
+#   SOFTPOSIT_ROOT -> path to soft-posit-cpp (must contain include/ and src/)
+#   BOOST_INC      -> path to Boost headers if not in default include path
+#   TIME_CMD       -> timing tool; defaults to '/usr/bin/time -l' on macOS, 'time' elsewhere
+
+set -euo pipefail
+
+# --- Detect platform timing command ---
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  : "${TIME_CMD:=/usr/bin/time -l}"
+else
+  : "${TIME_CMD:=/usr/bin/time}"
+fi
+
+# --- Absolute paths (defaults for this workspace) ---
+REPO_ROOT="/Users/inbasekaranperumal/Developer/OpenSource/LFX/jp-fractals-fork/Fractals-Posit-Fork"
+UNIVERSAL_INC_DEFAULT="/Users/inbasekaranperumal/Developer/OpenSource/LFX/universal/include/sw"
+SOFTPOSIT_ROOT_DEFAULT="/Users/inbasekaranperumal/Developer/OpenSource/LFX/soft-posit-cpp"
+BOOST_INC_DEFAULT="/opt/homebrew/include"
+
+# Allow overrides via environment variables
+: "${UNIVERSAL_INC:=${UNIVERSAL_INC_DEFAULT}}"
+: "${SOFTPOSIT_ROOT:=${SOFTPOSIT_ROOT_DEFAULT}}"
+: "${BOOST_INC:=${BOOST_INC_DEFAULT}}"
+
+echo "[info] Repository:            $REPO_ROOT"
+echo "[info] UNIVERSAL_INC:         $UNIVERSAL_INC"
+echo "[info] SOFTPOSIT_ROOT:        $SOFTPOSIT_ROOT"
+echo "[info] BOOST_INC:             $BOOST_INC"
+
+cd "$REPO_ROOT"
+
+echo "[step] Clean build directory"
+make clean || true
+
+echo "[step] Compile fractal binary (with SoftPosit static lib)"
+make BOOST_INC="$BOOST_INC" UNIVERSAL_INC="$UNIVERSAL_INC" SOFTPOSIT_ROOT="$SOFTPOSIT_ROOT" compile
+
+echo "[done] Build completed: $REPO_ROOT/build/fractal"
+
+# --- Optional runs ---
+if [[ "${RUN_BASELINE:-0}" == "1" ]]; then
+  echo "[run] Baseline cpp_dec_float_1000 mandelbrot -0.759 0 2.5 (this can be slow)"
+  (cd build && $TIME_CMD ./fractal cpp_dec_float_1000 mandelbrot -0.759 0 2.5)
+fi
+
+if [[ "${RUN_ALL:-0}" == "1" ]]; then
+  echo "[run] All dtypes for default view (can take a long time depending on baseline)"
+  (cd build && $TIME_CMD ./fractal all mandelbrot -0.759 0 2.5)
+fi
+
+echo "[hint] To compare images, run: make compare"

--- a/compare.py
+++ b/compare.py
@@ -108,8 +108,8 @@ def compare_sift(image1_path, image2_path):
     return similarity
 
 
-# Regex pattern (added softposit32/softposit16)
-dtype_group = r"(cfloat32_8|cfloat16_5|cfloat64_11|posit32_2|posit16_1|posit16_2|posit16_3|bfloat16_8|cfloat36_8|cfloat17_5|softposit32|softposit16)"
+# Regex pattern (added softposit32/softposit16 and cpp_dec_float_100)
+dtype_group = r"(cfloat32_8|cfloat16_5|cfloat64_11|posit32_2|posit16_1|posit16_2|posit16_3|bfloat16_8|cfloat36_8|cfloat17_5|softposit32|softposit16|cpp_dec_float_100)"
 mandelbrot_pattern = re.compile(
     rf"^mandelbrot_([+-]?\d+\.\d{{6}})_([+-]?\d+\.\d{{6}})_([0-9.eE+-]+)_{dtype_group}\.png$"
 )
@@ -168,7 +168,8 @@ with open(csv_path, "w", newline="") as csvfile:
     writer.writerow(header)
 
     for key, files in groups.items():
-        if "cfloat64_11" not in files:
+        # cpp_dec_float_100 is the new baseline
+        if "cpp_dec_float_100" not in files:
             continue
 
         def path(dtype):
@@ -179,7 +180,7 @@ with open(csv_path, "w", newline="") as csvfile:
             if dtype in files:
                 for metric_name, func, precision in metrics:
                     try:
-                        val = func(path(dtype), path("cfloat64_11"))
+                        val = func(path(dtype), path("cpp_dec_float_100"))
                     except Exception:
                         val = float("nan")
                     # handle inf and nan formatting explicitly

--- a/compare.py
+++ b/compare.py
@@ -108,8 +108,8 @@ def compare_sift(image1_path, image2_path):
     return similarity
 
 
-# Regex pattern (added softposit32/softposit16 and cpp_dec_float_100)
-dtype_group = r"(cfloat32_8|cfloat16_5|cfloat64_11|posit32_2|posit16_1|posit16_2|posit16_3|bfloat16_8|cfloat36_8|cfloat17_5|softposit32|softposit16|cpp_dec_float_100)"
+# Regex pattern (added softposit32/softposit16 and cpp_dec_float_1000)
+dtype_group = r"(cfloat32_8|cfloat16_5|cfloat64_11|posit32_2|posit16_1|posit16_2|posit16_3|bfloat16_8|cfloat36_8|cfloat17_5|softposit32|softposit16|cpp_dec_float_1000)"
 mandelbrot_pattern = re.compile(
     rf"^mandelbrot_([+-]?\d+\.\d{{6}})_([+-]?\d+\.\d{{6}})_([0-9.eE+-]+)_{dtype_group}\.png$"
 )
@@ -168,8 +168,8 @@ with open(csv_path, "w", newline="") as csvfile:
     writer.writerow(header)
 
     for key, files in groups.items():
-        # cpp_dec_float_100 is the new baseline
-        if "cpp_dec_float_100" not in files:
+        # cpp_dec_float_1000 is the new baseline
+        if "cpp_dec_float_1000" not in files:
             continue
 
         def path(dtype):
@@ -180,7 +180,7 @@ with open(csv_path, "w", newline="") as csvfile:
             if dtype in files:
                 for metric_name, func, precision in metrics:
                     try:
-                        val = func(path(dtype), path("cpp_dec_float_100"))
+                        val = func(path(dtype), path("cpp_dec_float_1000"))
                     except Exception:
                         val = float("nan")
                     # handle inf and nan formatting explicitly

--- a/fractal.cpp
+++ b/fractal.cpp
@@ -139,6 +139,8 @@ template <typename T>
 void fractal(int argc, char *argv[], unsigned char *image) {
   fractal_args_t<T> fractal_args;
   interpret_args<T>(argc, argv, fractal_args);
+  const char *fr_name = (fractal_args.fractal_type == MANDELBROT) ? "mandelbrot" : "julia_set";
+  printf("Running dtype=%s, fractal=%s\n", argv[1], fr_name);
   draw<T>(image, fractal_args);
   write_image(argv, image, fractal_args.fractal_type);
 }

--- a/fractal.cpp
+++ b/fractal.cpp
@@ -159,8 +159,8 @@ int main(int argc, char *argv[]) {
 
   if (strcmp(argv[1], "posit32_2") == 0) {
     fractal<sw::universal::posit<32, 2>>(argc, argv, image);
-  } else if (strcmp(argv[1], "cpp_dec_float_100") == 0) {
-    fractal<cpp_dec_float_100>(argc, argv, image);
+  } else if (strcmp(argv[1], "cpp_dec_float_1000") == 0) {
+    fractal<cpp_dec_float_1000>(argc, argv, image);
   } else if (strcmp(argv[1], "posit16_1") == 0) {
     fractal<sw::universal::posit<16, 1>>(argc, argv, image);
   } else if (strcmp(argv[1], "posit16_2") == 0) {
@@ -186,8 +186,8 @@ int main(int argc, char *argv[]) {
     fractal<posit16>(argc, argv, image);
 #endif
   } else { // all
-    argv[1] = const_cast<char *>("cpp_dec_float_100");
-    fractal<cpp_dec_float_100>(argc, argv, image);
+    argv[1] = const_cast<char *>("cpp_dec_float_1000");
+    fractal<cpp_dec_float_1000>(argc, argv, image);
     argv[1] = const_cast<char *>("posit32_2");
     fractal<sw::universal::posit<32, 2>>(argc, argv, image);
     argv[1] = const_cast<char *>("posit16_1");

--- a/fractal.cpp
+++ b/fractal.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <boost/multiprecision/cpp_dec_float.hpp>
 
 static inline void generate_palette(unsigned char palette[256][3]) {
   for (int i = 0; i < 256; i++) {
@@ -158,6 +159,8 @@ int main(int argc, char *argv[]) {
 
   if (strcmp(argv[1], "posit32_2") == 0) {
     fractal<sw::universal::posit<32, 2>>(argc, argv, image);
+  } else if (strcmp(argv[1], "cpp_dec_float_100") == 0) {
+    fractal<cpp_dec_float_100>(argc, argv, image);
   } else if (strcmp(argv[1], "posit16_1") == 0) {
     fractal<sw::universal::posit<16, 1>>(argc, argv, image);
   } else if (strcmp(argv[1], "posit16_2") == 0) {
@@ -183,6 +186,8 @@ int main(int argc, char *argv[]) {
     fractal<posit16>(argc, argv, image);
 #endif
   } else { // all
+    argv[1] = const_cast<char *>("cpp_dec_float_100");
+    fractal<cpp_dec_float_100>(argc, argv, image);
     argv[1] = const_cast<char *>("posit32_2");
     fractal<sw::universal::posit<32, 2>>(argc, argv, image);
     argv[1] = const_cast<char *>("posit16_1");

--- a/fractal.hpp
+++ b/fractal.hpp
@@ -1,7 +1,7 @@
 #ifndef __FRACTAL__H__
 #define __FRACTAL__H__
 
-#include <universal/number/bfloat/bfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
 #include <universal/number/cfloat/cfloat.hpp>
 #include <universal/number/posit/posit.hpp>
 #include <boost/multiprecision/cpp_dec_float.hpp>
@@ -10,7 +10,7 @@
 #endif
 
 namespace bmp = boost::multiprecision;
-typedef bmp::number<bmp::cpp_dec_float<100> > cpp_dec_float_100;
+typedef bmp::number<bmp::cpp_dec_float<1000> > cpp_dec_float_1000;
 
 #define WIDTH 800
 #define HEIGHT 600

--- a/fractal.hpp
+++ b/fractal.hpp
@@ -4,9 +4,13 @@
 #include <universal/number/bfloat/bfloat.hpp>
 #include <universal/number/cfloat/cfloat.hpp>
 #include <universal/number/posit/posit.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
 #ifdef ENABLE_SOFTPOSIT
 #include <softposit_cpp.h>
 #endif
+
+namespace bmp = boost::multiprecision;
+typedef bmp::number<bmp::cpp_dec_float<100> > cpp_dec_float_100;
 
 #define WIDTH 800
 #define HEIGHT 600

--- a/fractal.hpp
+++ b/fractal.hpp
@@ -4,6 +4,9 @@
 #include <universal/number/bfloat/bfloat.hpp>
 #include <universal/number/cfloat/cfloat.hpp>
 #include <universal/number/posit/posit.hpp>
+#ifdef ENABLE_SOFTPOSIT
+#include <softposit_cpp.h>
+#endif
 
 #define WIDTH 800
 #define HEIGHT 600


### PR DESCRIPTION
This PR adds [SoftPosit](https://github.com/Posit-Foundation/soft-posit-cpp) support alongside existing [IEEE-754](https://en.wikipedia.org/wiki/IEEE_754) and [Universal formats](https://github.com/stillwater-sc/universal), expands comparison metrics, and makes the build/run process reproducible across machines (macOS/Linux).

- **New formats**: `softposit32`, `softposit16` (via SoftPosit)
- **New metrics**: PSNR, MSE, corrected FFT RMSE
- **Reproducible build**: environment-configurable include paths; macOS OpenMP auto-detection; softposit static lib built automatically
- **Docs**: consolidated, setup and troubleshooting

### Changes by file
- `fractal.hpp`
  - Conditionally include SoftPosit when `ENABLE_SOFTPOSIT` is defined.
- `fractal.cpp`
  - Added `softposit32` and `softposit16` dtype support in `main`.
  - Refactored `generate_palette` to a simple double-based function.
  - Improved `error_message` usage/help text; added allocation check for the image buffer.
- `Makefile`
  - macOS OpenMP auto-detection (Homebrew LLVM/libomp) with sensible fallbacks.
  - `UNIVERSAL_INC` and `SOFTPOSIT_ROOT` environment variables to locate headers and SoftPosit sources.
  - Builds SoftPosit into `build/libsoftposit.a` and links it automatically when `SOFTPOSIT_ROOT` is set (defines `ENABLE_SOFTPOSIT`).
  - Added targets for `softposit32` and `softposit16`; `install` now includes `scipy`.
- `compare.py`
  - Added `psnr` and `mse`; fixed `fft_rmse` to RMSE of log-magnitude spectra.
  - Included SoftPosit dtypes in regex grouping and CSV output.
  - Leave missing entries blank.
- `README.md`
  - Add the following sections: prerequisites, environment setup (`UNIVERSAL_INC`, `SOFTPOSIT_ROOT`), build/run instructions, metrics, and troubleshooting.
  - Clarified dtype selection and baseline (`cfloat64_11`).

### How to test
- Build:
  - `make install`
  - `make UNIVERSAL_INC="/abs/path/to/universal/include/sw" SOFTPOSIT_ROOT="/abs/path/to/soft-posit-cpp" compile`
- Quick run (from `build/`):
  - `./fractal cfloat64_11 mandelbrot -0.759 0.000 2.500`
  - `./fractal softposit32  mandelbrot -0.759 0.000 2.500`
  - `./fractal softposit16  mandelbrot -0.759 0.000 2.500`
- Compare:
  - `python3 compare.py` (CSV at `build/comparison_results.csv`)

### Notes
- If `SOFTPOSIT_ROOT` is not provided, the project builds and runs without SoftPosit (Universal/IEEE only).
- macOS users: `brew install llvm libomp` is recommended; Makefile auto-detects these.